### PR TITLE
Update resend.mdx

### DIFF
--- a/integrations/resend.mdx
+++ b/integrations/resend.mdx
@@ -90,11 +90,12 @@ Resend provides reliable email delivery and tracking for your application's emai
 
 <Steps>
   <Step title="Add the Integration">
-    1. In your Create project, type `/` in chat
-    2. Select "Resend" from the menu
+    1. In your Anything Project Settings, go to Saved Secrets
+    2. Click "Add new secret"
   </Step>
   <Step title="Add Your API Key">
-    1. Paste your Resend API key into "RESEND_API_KEY" secret
+    1. Name the new secret "RESEND_API_KEY"
+    2. Paste your Resend API key into the Secret Value field
 
     <Tip>
       Need a new key? Regenerate in Resend dashboard.


### PR DESCRIPTION
Corrects the instructions for adding your Resend API key.

When I followed the instructions as they're currently published, selecting "Resend" from the menu did not prompt an action that allowed me to paste my API key.

<img width="488" height="206" alt="image" src="https://github.com/user-attachments/assets/b0541961-4ac8-4748-b5a4-b2acc1fb2ec2" />
